### PR TITLE
redis setex went from (key, value, expire) to (key, expire, value)

### DIFF
--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -17,7 +17,7 @@ version_info_t = namedtuple(
 )
 
 SERIES = 'Cipater'
-VERSION = version_info_t(3, 1, 420, '', '')
+VERSION = version_info_t(3, 1, 421, '', '')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/celery/backends/redis.py
+++ b/celery/backends/redis.py
@@ -162,7 +162,7 @@ class RedisBackend(KeyValueStoreBackend):
     def _set(self, key, value):
         with self.client.pipeline() as pipe:
             if self.expires:
-                pipe.setex(key, value, self.expires)
+                pipe.setex(key, self.expires, value)
             else:
                 pipe.set(key, value)
             pipe.publish(key, value)


### PR DESCRIPTION
We're upgrading redis to 3.5.3 to use redbeat. Theres a change in order of arguments for the `setex` command that this PR fixes.